### PR TITLE
Fixed >4GiB framebuffer allocation

### DIFF
--- a/inc/gpu/nvidia/resources.h
+++ b/inc/gpu/nvidia/resources.h
@@ -42,7 +42,7 @@ struct NvResource {
                                 //!< of the resource's lifecycle.
     uint32_t client;            //!< All resources require a client/root.
     uint32_t parent;            //!< Parent of the resource.
-    uint64_t object;            //!< Object of the resource.
+    uint32_t object;            //!< Object of the resource.
     uint32_t rm_class;          //!< Class of the resource.
     void *class_info;           //!< Class info for the resource.
     struct NvResource* next;    //!< Next child on the level.

--- a/inc/gpu/nvidia/resources.h
+++ b/inc/gpu/nvidia/resources.h
@@ -42,7 +42,7 @@ struct NvResource {
                                 //!< of the resource's lifecycle.
     uint32_t client;            //!< All resources require a client/root.
     uint32_t parent;            //!< Parent of the resource.
-    uint32_t object;            //!< Object of the resource.
+    uint64_t object;            //!< Object of the resource.
     uint32_t rm_class;          //!< Class of the resource.
     void *class_info;           //!< Class info for the resource.
     struct NvResource* next;    //!< Next child on the level.

--- a/src/lib/gpu/nvidia/manager.c
+++ b/src/lib/gpu/nvidia/manager.c
@@ -254,9 +254,9 @@ void create_nv_mgr_mdevs(
             mdev.p_dev_id =
                 request.p_dev_id == 0xFFFFFFFFFFFFFFFF ?
                 ggpu->device_id : request.p_dev_id;
-            mdev.fb_len = request.fb_len * 1024 * 1024;
+            mdev.fb_len = (uint64_t) request.fb_len * 1024 * 1024;
             mdev.map_video = request.map_vid_size * 1024 * 1024;
-            mdev.fb_res = request.fb_res * 1024 * 1024;
+            mdev.fb_res = (uint64_t) request.fb_res * 1024 * 1024;
             mdev.bar1_len = request.bar1_len;
 
             RM_CTRL(gpu->ctl_fd, gpu->mdev, NVA081_ADD_MDEV, mdev);


### PR DESCRIPTION
I couldn't allocate more than 4GiB on my vgpu on GVM-User but I could on Mdev-gpu, so looking at the code I found this commit https://github.com/Arc-Compute/Mdev-GPU/commit/b55b976fbffabd3ce4fe21543ca9b812152140a5.

I ported it in the GVM-user codebase by casting the allocation for mdev.fb_len on line 257 and 259 to uint64_t as it would produce an uint32_t instead, which is upper bound to a value of 2^32.

I then modified line 45 of the resources.h header file by changing the declaration of the Resource object to uint64_t aswell (which imo should have been that from the start given that RmMdevConfig contains other uint64_t objects). 